### PR TITLE
new review for generator size efficiency ratio

### DIFF
--- a/src/helpers/genericHelpers.js
+++ b/src/helpers/genericHelpers.js
@@ -135,7 +135,7 @@ const getGeneratorSizeMessage = (percent) => {
     message = 'Fairly Efficient Loading';
     color = '#008000';
   } else {
-    message = 'Under Utilized';
+    message = 'Inefficient';
     color = '#FFBF00';
 
   }


### PR DESCRIPTION
The Label(Under Utilized) has now been changed to (Inefficient).