### PR TITLE
hide cost-tracker for Bespoke customer

### DIFF
--- a/src/components/AppHeader.js
+++ b/src/components/AppHeader.js
@@ -120,7 +120,7 @@ function Header() {
           }
           {
             // BESPOKE_ADD_LIST.COST_TRACKER.includes(userData.client) &&
-            <HeaderLink onClick={toggleNav} url="/cost-tracker" linkText="Cost Tracker" />
+            // <HeaderLink onClick={toggleNav} url="/cost-tracker" linkText="Cost Tracker" />
           }
           {
             BESPOKE_ADD_LIST.REPORT.includes(userData.client) &&


### PR DESCRIPTION
we are hiding the cost-tracker page for the bespoke client type, for now, we will show it back maybe tomorrow